### PR TITLE
Lowercase on switch to give correct board

### DIFF
--- a/commands/search.js
+++ b/commands/search.js
@@ -14,7 +14,7 @@ module.exports.run = async (client, message, args) => {
         return message.channel.send("Not a valid board.")
     }
     var boardID
-    switch(board){
+    switch(board.toLowerCase()){
         case "desktop":
             boardID = config.trello.desktop_bugs
         break;


### PR DESCRIPTION
On the if it's a correct board it searches on lowercase causing it to be correct, however if you do an upper case it will always use the default in the switch instead of the correct board!