### PR TITLE
 Fix bot not responding if the card title was over 250 characters 

### DIFF
--- a/commands/search.js
+++ b/commands/search.js
@@ -116,11 +116,11 @@ module.exports.run = async (client, message, args) => {
                 await resultsEmbed.setImage(cards[0].attachments[0].url)
             }
             if (cards[0].name.length > 250) {
-				await resultsEmbed.setTitle(cards[0].name.substring(0, 247) + "...")
-			}
-			else {
-				await resultsEmbed.setTitle(cards[0].name)
-			}
+		await resultsEmbed.setTitle(cards[0].name.substring(0, 247) + "...")
+	    }
+	    else {
+		await resultsEmbed.setTitle(cards[0].name)
+	    }
             await resultsEmbed.setDescription(`Labels: ${finalLabels}\nList: ${JSON.parse(bodytwo).name}\nArchived: ${cards[0].closed}\n\n${final}\n\nLink: ${cards[0].shortUrl}`)
             await resultsEmbed.setColor("#ff3535")
             await resultsEmbed.setFooter(`Executed by ${message.author.tag}`, message.author.avatarURL)

--- a/commands/search.js
+++ b/commands/search.js
@@ -115,7 +115,12 @@ module.exports.run = async (client, message, args) => {
             if(cards[0].attachments.length !== 0){
                 await resultsEmbed.setImage(cards[0].attachments[0].url)
             }
-            await resultsEmbed.setTitle(cards[0].name)
+            if (cards[0].name.length > 250) {
+				await resultsEmbed.setTitle(cards[0].name.substring(0, 247) + "...")
+			}
+			else {
+				await resultsEmbed.setTitle(cards[0].name)
+			}
             await resultsEmbed.setDescription(`Labels: ${finalLabels}\nList: ${JSON.parse(bodytwo).name}\nArchived: ${cards[0].closed}\n\n${final}\n\nLink: ${cards[0].shortUrl}`)
             await resultsEmbed.setColor("#ff3535")
             await resultsEmbed.setFooter(`Executed by ${message.author.tag}`, message.author.avatarURL)


### PR DESCRIPTION
Fixes the bot not sending an embed if a card title is greater than 250 characters and the results return only one card. Example: https://i.imgur.com/YCMQRyh.png for https://trello.com/c/LCgNnD2s